### PR TITLE
refactor: rename auth controller to oidc and update URL paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,8 @@ pkg/
 **Auth flow**: User logs in via OIDC -> coordinator creates Headscale user -> generates session token -> user creates join token -> worker exchanges token for PreAuthKey -> runs `tailscale up` with authkey.
 
 **Coordinator endpoints**:
-- `/auth/login?provider=github` - Start OIDC flow
-- `/auth/callback` - OIDC callback, creates realm
+- `/oidc/login?provider=github` - Start OIDC flow
+- `/oidc/callback` - OIDC callback, creates realm
 - `/api/v1/join-token` - Generate JWT for worker join (needs `X-Session-Token` header)
 - `/api/v1/worker/join` - Worker exchanges JWT for Headscale PreAuthKey
 - `/api/v1/nodes` - List nodes (supports `X-Session-Token` or `Authorization: Bearer <api_key>`)

--- a/e2e/docker-compose.yaml
+++ b/e2e/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
       OIDC_ISSUER: http://localhost:9090/realms/wonder
       OIDC_CLIENT_ID: wonder
       OIDC_CLIENT_SECRET: wonder-secret
-      OIDC_REDIRECT_URI: http://localhost:9080/coordinator/auth/callback
+      OIDC_REDIRECT_URI: http://localhost:9080/coordinator/oidc/callback
     volumes:
       - ./headscale-config.yaml:/etc/headscale/config.yaml
       - coordinator-data:/data

--- a/e2e/test.sh
+++ b/e2e/test.sh
@@ -82,7 +82,7 @@ rm -f "$COOKIE_JAR"
 
 log_info "Starting login flow..."
 LOGIN_REDIRECT=$(curl -s -D - -o /dev/null -c "$COOKIE_JAR" -b "$COOKIE_JAR" \
-    "http://localhost:9080/coordinator/auth/login?provider=oidc" \
+    "http://localhost:9080/coordinator/oidc/login?provider=oidc" \
     | grep -i "^location:" | sed 's/location: //i' | tr -d '\r')
 
 if [ -z "$LOGIN_REDIRECT" ]; then

--- a/internal/app/coordinator/bootstrap.go
+++ b/internal/app/coordinator/bootstrap.go
@@ -18,7 +18,7 @@ import (
 // and handles graceful shutdown on SIGINT or SIGTERM with a 10-second timeout.
 func (s *Server) Run() error {
 	healthController := controller.NewHealthController(s.headscaleClient)
-	authController := controller.NewAuthController(s.oidcService, s.authService, s.realmService, s.config.PublicURL)
+	oidcController := controller.NewOIDCController(s.oidcService, s.authService, s.realmService, s.config.PublicURL)
 	nodesController := controller.NewNodesController(s.nodesService, s.authService)
 	apiKeyController := controller.NewAPIKeyController(s.apiKeyRepository, s.authService)
 	deployerController := controller.NewDeployerController(s.realmService, s.authService)
@@ -32,11 +32,11 @@ func (s *Server) Run() error {
 
 	coordinatorRouter := chi.NewRouter()
 	coordinatorRouter.Get("/health", healthController.ServeHTTP)
-	coordinatorRouter.Get("/auth/providers", authController.HandleProviders)
-	coordinatorRouter.Get("/auth/login", authController.HandleLogin)
-	coordinatorRouter.Get("/auth/callback", authController.HandleCallback)
-	coordinatorRouter.Get("/auth/complete", authController.HandleComplete)
-	coordinatorRouter.Post("/api/v1/authkey", authController.HandleCreateAuthKey)
+	coordinatorRouter.Get("/oidc/providers", oidcController.HandleProviders)
+	coordinatorRouter.Get("/oidc/login", oidcController.HandleLogin)
+	coordinatorRouter.Get("/oidc/callback", oidcController.HandleCallback)
+	coordinatorRouter.Get("/oidc/complete", oidcController.HandleComplete)
+	coordinatorRouter.Post("/api/v1/authkey", oidcController.HandleCreateAuthKey)
 	coordinatorRouter.Get("/api/v1/nodes", nodesController.HandleListNodes)
 	coordinatorRouter.Get("/api/v1/api-keys", apiKeyController.HandleListAPIKeys)
 	coordinatorRouter.Post("/api/v1/api-keys", apiKeyController.HandleCreateAPIKey)

--- a/internal/app/coordinator/config.go
+++ b/internal/app/coordinator/config.go
@@ -27,11 +27,11 @@ type Config struct {
 }
 
 // OIDCProviders returns the configured OIDC providers based on the config fields.
-// RedirectURL is set to {PublicURL}/coordinator/auth/callback for all providers.
+// RedirectURL is set to {PublicURL}/coordinator/oidc/callback for all providers.
 func (c *Config) OIDCProviders() []oidc.ProviderConfig {
 	var providers []oidc.ProviderConfig
 
-	redirectURL := c.PublicURL + "/coordinator/auth/callback"
+	redirectURL := c.PublicURL + "/coordinator/oidc/callback"
 
 	if c.GithubClientID != "" {
 		providers = append(providers, oidc.ProviderConfig{

--- a/internal/app/coordinator/controller/device.go
+++ b/internal/app/coordinator/controller/device.go
@@ -187,7 +187,7 @@ func (c *DeviceController) HandleDeviceVerifyPage(w http.ResponseWriter, r *http
                 } else if (resp.status === 401) {
                     loginPrompt.style.display = 'block';
                     document.getElementById('login-link').href =
-                        '/coordinator/auth/login?provider=github&redirect=' +
+                        '/coordinator/oidc/login?provider=github&redirect=' +
                         encodeURIComponent(window.location.href);
                     errorDiv.textContent = data.error || 'Please login first';
                 } else {

--- a/internal/app/coordinator/controller/oidc.go
+++ b/internal/app/coordinator/controller/oidc.go
@@ -10,22 +10,22 @@ import (
 	"github.com/strrl/wonder-mesh-net/internal/app/coordinator/service"
 )
 
-// AuthController handles OIDC authentication flows.
-type AuthController struct {
+// OIDCController handles OIDC authentication flows.
+type OIDCController struct {
 	oidcService  *service.OIDCService
 	authService  *service.AuthService
 	realmService *service.RealmService
 	publicURL    string
 }
 
-// NewAuthController creates a new AuthController.
-func NewAuthController(
+// NewOIDCController creates a new OIDCController.
+func NewOIDCController(
 	oidcService *service.OIDCService,
 	authService *service.AuthService,
 	realmService *service.RealmService,
 	publicURL string,
-) *AuthController {
-	return &AuthController{
+) *OIDCController {
+	return &OIDCController{
 		oidcService:  oidcService,
 		authService:  authService,
 		realmService: realmService,
@@ -33,8 +33,8 @@ func NewAuthController(
 	}
 }
 
-// HandleProviders handles GET /auth/providers requests.
-func (c *AuthController) HandleProviders(w http.ResponseWriter, r *http.Request) {
+// HandleProviders handles GET /oidc/providers requests.
+func (c *OIDCController) HandleProviders(w http.ResponseWriter, r *http.Request) {
 	providers := c.oidcService.ListProviders()
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]interface{}{
@@ -44,8 +44,8 @@ func (c *AuthController) HandleProviders(w http.ResponseWriter, r *http.Request)
 	}
 }
 
-// HandleLogin handles GET /auth/login requests.
-func (c *AuthController) HandleLogin(w http.ResponseWriter, r *http.Request) {
+// HandleLogin handles GET /oidc/login requests.
+func (c *OIDCController) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	providerName := r.URL.Query().Get("provider")
 	if providerName == "" {
 		http.Error(w, "provider parameter required", http.StatusBadRequest)
@@ -70,8 +70,8 @@ func (c *AuthController) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, authURL, http.StatusFound)
 }
 
-// HandleCallback handles GET /auth/callback requests.
-func (c *AuthController) HandleCallback(w http.ResponseWriter, r *http.Request) {
+// HandleCallback handles GET /oidc/callback requests.
+func (c *OIDCController) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	code := r.URL.Query().Get("code")
@@ -126,8 +126,8 @@ func (c *AuthController) HandleCallback(w http.ResponseWriter, r *http.Request) 
 	http.Redirect(w, r, redirectURI, http.StatusFound)
 }
 
-// HandleComplete handles GET /auth/complete requests.
-func (c *AuthController) HandleComplete(w http.ResponseWriter, r *http.Request) {
+// HandleComplete handles GET /oidc/complete requests.
+func (c *OIDCController) HandleComplete(w http.ResponseWriter, r *http.Request) {
 	var session, user string
 
 	if cookie, err := r.Cookie("wonder_session"); err == nil {
@@ -152,7 +152,7 @@ func (c *AuthController) HandleComplete(w http.ResponseWriter, r *http.Request) 
 }
 
 // HandleCreateAuthKey handles POST /api/v1/authkey requests.
-func (c *AuthController) HandleCreateAuthKey(w http.ResponseWriter, r *http.Request) {
+func (c *OIDCController) HandleCreateAuthKey(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return

--- a/internal/app/coordinator/service/oidc.go
+++ b/internal/app/coordinator/service/oidc.go
@@ -54,7 +54,7 @@ func (s *OIDCService) InitiateLogin(ctx context.Context, providerName, redirectU
 	}
 
 	if redirectURI == "" {
-		redirectURI = publicURL + "/coordinator/auth/complete"
+		redirectURI = publicURL + "/coordinator/oidc/complete"
 	} else if !isValidRedirectURI(publicURL, redirectURI) {
 		return "", ErrInvalidRedirectURI
 	}


### PR DESCRIPTION
## Summary
- Rename `auth.go` to `oidc.go` and `AuthController` to `OIDCController`
- Change all `/auth/*` URL paths to `/oidc/*` for OIDC authentication endpoints
- Update all references in config, service, e2e tests, and documentation

## Test plan
- [ ] Verify OIDC login flow works via `/coordinator/oidc/login?provider=github`
- [ ] Verify callback redirects correctly to `/coordinator/oidc/callback`
- [ ] Run e2e tests with `make e2e-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)