### PR TITLE
refactor: change join token endpoint from POST to GET

### DIFF
--- a/docs/AUTH_DESIGN.md
+++ b/docs/AUTH_DESIGN.md
@@ -311,7 +311,7 @@ sequenceDiagram
 |----------|:-----------:|:-------:|:----:|-------|
 | `GET /coordinator/oidc/login` | - | - | ✅ | Start OIDC flow |
 | `GET /coordinator/oidc/callback` | - | - | ✅ | OIDC callback |
-| `POST /coordinator/api/v1/join-token` | ✅ | ❌ | - | Privileged: generate join token |
+| `GET /coordinator/api/v1/join-token` | ✅ | ❌ | - | Privileged: generate join token |
 | `GET /coordinator/api/v1/api-keys` | ✅ | ❌ | - | Privileged: list API keys |
 | `POST /coordinator/api/v1/api-keys` | ✅ | ❌ | - | Privileged: create API key |
 | `DELETE /coordinator/api/v1/api-keys/{id}` | ✅ | ❌ | - | Privileged: delete API key |

--- a/e2e/test.sh
+++ b/e2e/test.sh
@@ -113,9 +113,8 @@ fi
 log_info "Access token obtained: ${ACCESS_TOKEN:0:50}..."
 
 log_info "Creating join token..."
-JOIN_TOKEN_RESPONSE=$(docker exec deployer curl -s -X POST \
+JOIN_TOKEN_RESPONSE=$(docker exec deployer curl -s \
     -H "Authorization: Bearer $ACCESS_TOKEN" \
-    -H "Content-Type: application/json" \
     "http://nginx/coordinator/api/v1/join-token")
 
 JOIN_TOKEN=$(echo "$JOIN_TOKEN_RESPONSE" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')

--- a/internal/app/coordinator/controller/jointoken.go
+++ b/internal/app/coordinator/controller/jointoken.go
@@ -27,10 +27,10 @@ type JoinTokenResponse struct {
 	ExpiresIn int    `json:"expires_in"`
 }
 
-// HandleCreateJoinToken handles POST /api/v1/join-token requests.
+// HandleCreateJoinToken handles GET /api/v1/join-token requests.
 // Creates a JWT join token for worker nodes.
 func (c *JoinTokenController) HandleCreateJoinToken(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
+	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}

--- a/internal/app/coordinator/server.go
+++ b/internal/app/coordinator/server.go
@@ -344,7 +344,7 @@ func (s *Server) Run() error {
 	mux.HandleFunc("POST /coordinator/api/v1/worker/join", workerController.HandleWorkerJoin)
 
 	// Protected endpoints - require JWT authentication and WonderNet
-	mux.HandleFunc("POST /coordinator/api/v1/join-token", s.requireAuth(s.requireWonderNet(joinTokenController.HandleCreateJoinToken)))
+	mux.HandleFunc("GET /coordinator/api/v1/join-token", s.requireAuth(s.requireWonderNet(joinTokenController.HandleCreateJoinToken)))
 
 	// Read-only endpoints - support both JWT session auth and API key auth
 	mux.HandleFunc("GET /coordinator/api/v1/nodes", s.requireAuthOrAPIKey(nodesController.HandleListNodes))


### PR DESCRIPTION
close https://github.com/STRRL/wonder-mesh-net/pull/61

The /coordinator/api/v1/join-token endpoint now uses GET instead of POST since token creation is idempotent and doesn't require a request body.

Changes:
- Update route handler from POST to GET in server.go
- Update controller method check from MethodPost to MethodGet
- Remove Content-Type header from e2e test request
- Update AUTH_DESIGN.md documentation table