### PR TITLE
feat: add secretExtraEnv support for coordinator

### DIFF
--- a/charts/wonder-mesh-net/templates/deployment.yaml
+++ b/charts/wonder-mesh-net/templates/deployment.yaml
@@ -94,6 +94,9 @@ spec:
             {{- with .Values.coordinator.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- with .Values.coordinator.secretExtraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: headscale-socket
               mountPath: /var/run/headscale

--- a/charts/wonder-mesh-net/values.schema.json
+++ b/charts/wonder-mesh-net/values.schema.json
@@ -314,6 +314,14 @@
             { "type": "null" }
           ]
         },
+        "extraEnv": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
+        "secretExtraEnv": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
         "nodeSelector": {
           "type": "object",
           "additionalProperties": { "type": "string" }

--- a/charts/wonder-mesh-net/values.yaml
+++ b/charts/wonder-mesh-net/values.yaml
@@ -184,6 +184,8 @@ coordinator:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+  extraEnv: []
+  secretExtraEnv: []
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
Allow secrets to be injected as extra env vars via a separate coordinator.secretExtraEnv key, merged with coordinator.extraEnv in the deployment template. This avoids YAML list override conflicts when using helmfile with sops-encrypted values.