### PR TITLE
feat: make admin deployer join credentials reusable with 100-year TTL

### DIFF
--- a/internal/app/coordinator/controller/admin.go
+++ b/internal/app/coordinator/controller/admin.go
@@ -371,8 +371,8 @@ func (c *AdminController) HandleAdminDeployerJoin(w http.ResponseWriter, r *http
 	}
 
 	metadata, err := c.meshBackend.CreateJoinCredentials(r.Context(), wonderNet.HeadscaleUser, meshbackend.JoinOptions{
-		TTL:       24 * time.Hour,
-		Reusable:  false,
+		TTL:       100 * 365 * 24 * time.Hour,
+		Reusable:  true,
 		Ephemeral: false,
 	})
 	if err != nil {


### PR DESCRIPTION
Admin-issued deployer authkeys are used for long-running infrastructure like SOCKS5 gateway pods. Single-use keys with 24h TTL caused failures on pod restarts when PVC state was lost.