### PR TITLE
feat: add constant-size tag-based ACL policy

### DIFF
--- a/cmd/wonder/commands/coordinator.go
+++ b/cmd/wonder/commands/coordinator.go
@@ -26,6 +26,7 @@ func NewCoordinatorCmd() *cobra.Command {
 	cmd.Flags().String("db-dsn", "", "Database connection string")
 	cmd.Flags().Bool("enable-admin-api", false, "Enable admin API endpoints")
 	cmd.Flags().StringArray("privileged-networks", nil, "Headscale usernames with hub-spoke access to all WonderNets (repeatable)")
+	cmd.Flags().Bool("use-tagged-acl", false, "Use constant-size tag-based ACL policy (recommended for many WonderNets)")
 
 	_ = viper.BindPFlag("coordinator.listen", cmd.Flags().Lookup("listen"))
 	_ = viper.BindPFlag("coordinator.public_url", cmd.Flags().Lookup("public-url"))
@@ -33,6 +34,7 @@ func NewCoordinatorCmd() *cobra.Command {
 	_ = viper.BindPFlag("coordinator.database_dsn", cmd.Flags().Lookup("db-dsn"))
 	_ = viper.BindPFlag("coordinator.enable_admin_api", cmd.Flags().Lookup("enable-admin-api"))
 	_ = viper.BindPFlag("coordinator.privileged_networks", cmd.Flags().Lookup("privileged-networks"))
+	_ = viper.BindPFlag("coordinator.use_tagged_acl", cmd.Flags().Lookup("use-tagged-acl"))
 
 	_ = viper.BindEnv("coordinator.listen", "LISTEN")
 	_ = viper.BindEnv("coordinator.public_url", "PUBLIC_URL")
@@ -48,6 +50,7 @@ func NewCoordinatorCmd() *cobra.Command {
 	_ = viper.BindEnv("coordinator.enable_admin_api", "ENABLE_ADMIN_API")
 	_ = viper.BindEnv("coordinator.admin_api_auth_token", "ADMIN_API_AUTH_TOKEN")
 	_ = viper.BindEnv("coordinator.privileged_networks", "PRIVILEGED_NETWORKS")
+	_ = viper.BindEnv("coordinator.use_tagged_acl", "USE_TAGGED_ACL")
 
 	return cmd
 }
@@ -71,6 +74,7 @@ func runCoordinator(cmd *cobra.Command, args []string) {
 	cfg.AdminAPIAuthToken = viper.GetString("coordinator.admin_api_auth_token")
 
 	cfg.PrivilegedNetworks = parseStringSlice(viper.Get("coordinator.privileged_networks"))
+	cfg.UseTaggedACL = viper.GetBool("coordinator.use_tagged_acl")
 
 	if cfg.HeadscaleURL == "" {
 		cfg.HeadscaleURL = coordinator.DefaultHeadscaleURL
@@ -108,7 +112,7 @@ func runCoordinator(cmd *cobra.Command, args []string) {
 	}
 
 	if len(cfg.PrivilegedNetworks) > 0 {
-		slog.Info("privileged networks configured", "networks", cfg.PrivilegedNetworks)
+		slog.Info("privileged networks configured", "networks", cfg.PrivilegedNetworks, "use_tagged_acl", cfg.UseTaggedACL)
 	}
 
 	server, err := coordinator.BootstrapNewServer(&cfg)

--- a/cmd/wonder/commands/coordinator.go
+++ b/cmd/wonder/commands/coordinator.go
@@ -27,6 +27,7 @@ func NewCoordinatorCmd() *cobra.Command {
 	cmd.Flags().Bool("enable-admin-api", false, "Enable admin API endpoints")
 	cmd.Flags().StringArray("privileged-networks", nil, "Headscale usernames with hub-spoke access to all WonderNets (repeatable)")
 	cmd.Flags().Bool("use-tagged-acl", false, "Use constant-size tag-based ACL policy (recommended for many WonderNets)")
+	cmd.Flags().Bool("strict-privileged-tags", false, "Fail startup if any privileged node cannot be tagged (tagged-ACL mode only)")
 
 	_ = viper.BindPFlag("coordinator.listen", cmd.Flags().Lookup("listen"))
 	_ = viper.BindPFlag("coordinator.public_url", cmd.Flags().Lookup("public-url"))
@@ -35,6 +36,7 @@ func NewCoordinatorCmd() *cobra.Command {
 	_ = viper.BindPFlag("coordinator.enable_admin_api", cmd.Flags().Lookup("enable-admin-api"))
 	_ = viper.BindPFlag("coordinator.privileged_networks", cmd.Flags().Lookup("privileged-networks"))
 	_ = viper.BindPFlag("coordinator.use_tagged_acl", cmd.Flags().Lookup("use-tagged-acl"))
+	_ = viper.BindPFlag("coordinator.strict_privileged_tags", cmd.Flags().Lookup("strict-privileged-tags"))
 
 	_ = viper.BindEnv("coordinator.listen", "LISTEN")
 	_ = viper.BindEnv("coordinator.public_url", "PUBLIC_URL")
@@ -51,6 +53,7 @@ func NewCoordinatorCmd() *cobra.Command {
 	_ = viper.BindEnv("coordinator.admin_api_auth_token", "ADMIN_API_AUTH_TOKEN")
 	_ = viper.BindEnv("coordinator.privileged_networks", "PRIVILEGED_NETWORKS")
 	_ = viper.BindEnv("coordinator.use_tagged_acl", "USE_TAGGED_ACL")
+	_ = viper.BindEnv("coordinator.strict_privileged_tags", "STRICT_PRIVILEGED_TAGS")
 
 	return cmd
 }
@@ -75,6 +78,7 @@ func runCoordinator(cmd *cobra.Command, args []string) {
 
 	cfg.PrivilegedNetworks = parseStringSlice(viper.Get("coordinator.privileged_networks"))
 	cfg.UseTaggedACL = viper.GetBool("coordinator.use_tagged_acl")
+	cfg.StrictPrivilegedTags = viper.GetBool("coordinator.strict_privileged_tags")
 
 	if cfg.HeadscaleURL == "" {
 		cfg.HeadscaleURL = coordinator.DefaultHeadscaleURL

--- a/internal/app/coordinator/config.go
+++ b/internal/app/coordinator/config.go
@@ -43,6 +43,13 @@ type Config struct {
 	// WonderNets, where the per-user policy grows O(users) and slows down
 	// Headscale's RegisterReq / peer-map rebuild. Default off until verified.
 	UseTaggedACL bool `mapstructure:"use_tagged_acl"`
+
+	// StrictPrivilegedTags makes coordinator startup fail when any privileged
+	// node cannot be tagged during the tagged-ACL migration. When false
+	// (default), failures are logged and startup continues — successfully
+	// tagged nodes are still applied, and the constant-size policy remains
+	// correct. Only relevant when UseTaggedACL is true.
+	StrictPrivilegedTags bool `mapstructure:"strict_privileged_tags"`
 }
 
 const (

--- a/internal/app/coordinator/config.go
+++ b/internal/app/coordinator/config.go
@@ -37,6 +37,12 @@ type Config struct {
 	// PrivilegedNetworks is the list of Headscale usernames that have access to all
 	// WonderNets (hub-spoke ACL model). When empty, pure isolation policy is used.
 	PrivilegedNetworks []string
+
+	// UseTaggedACL switches the coordinator to the constant-size tag-based ACL
+	// policy backed by node forced_tags. Required for clusters with many
+	// WonderNets, where the per-user policy grows O(users) and slows down
+	// Headscale's RegisterReq / peer-map rebuild. Default off until verified.
+	UseTaggedACL bool `mapstructure:"use_tagged_acl"`
 }
 
 const (

--- a/internal/app/coordinator/server.go
+++ b/internal/app/coordinator/server.go
@@ -114,7 +114,7 @@ func BootstrapNewServer(config *Config) (*Server, error) {
 	meshBackend := tailscale.NewTailscaleMesh(headscaleClient, config.PublicURL)
 
 	// Create services
-	wonderNetService := service.NewWonderNetService(wonderNetRepository, wonderNetManager, aclManager, config.PublicURL, config.PrivilegedNetworks, config.UseTaggedACL)
+	wonderNetService := service.NewWonderNetService(wonderNetRepository, wonderNetManager, aclManager, config.PublicURL, config.PrivilegedNetworks, config.UseTaggedACL, config.StrictPrivilegedTags)
 	workerService := service.NewWorkerService(tokenGenerator, config.JWTSecret, wonderNetRepository, meshBackend)
 	nodesService := service.NewNodesService(meshBackend)
 	apiKeyService := service.NewAPIKeyService(apiKeyRepository, wonderNetRepository)

--- a/internal/app/coordinator/server.go
+++ b/internal/app/coordinator/server.go
@@ -114,7 +114,7 @@ func BootstrapNewServer(config *Config) (*Server, error) {
 	meshBackend := tailscale.NewTailscaleMesh(headscaleClient, config.PublicURL)
 
 	// Create services
-	wonderNetService := service.NewWonderNetService(wonderNetRepository, wonderNetManager, aclManager, config.PublicURL, config.PrivilegedNetworks)
+	wonderNetService := service.NewWonderNetService(wonderNetRepository, wonderNetManager, aclManager, config.PublicURL, config.PrivilegedNetworks, config.UseTaggedACL)
 	workerService := service.NewWorkerService(tokenGenerator, config.JWTSecret, wonderNetRepository, meshBackend)
 	nodesService := service.NewNodesService(meshBackend)
 	apiKeyService := service.NewAPIKeyService(apiKeyRepository, wonderNetRepository)

--- a/internal/app/coordinator/service/wondernet.go
+++ b/internal/app/coordinator/service/wondernet.go
@@ -24,6 +24,7 @@ type WonderNetService struct {
 	aclManager          *headscale.ACLManager
 	publicURL           string
 	privilegedNetworks  []string
+	useTaggedACL        bool
 }
 
 // NewWonderNetService creates a new WonderNetService.
@@ -33,6 +34,7 @@ func NewWonderNetService(
 	aclManager *headscale.ACLManager,
 	publicURL string,
 	privilegedNetworks []string,
+	useTaggedACL bool,
 ) *WonderNetService {
 	return &WonderNetService{
 		wonderNetRepository: wonderNetRepository,
@@ -40,6 +42,7 @@ func NewWonderNetService(
 		aclManager:          aclManager,
 		publicURL:           publicURL,
 		privilegedNetworks:  privilegedNetworks,
+		useTaggedACL:        useTaggedACL,
 	}
 }
 
@@ -65,8 +68,13 @@ func (s *WonderNetService) ProvisionWonderNet(ctx context.Context, userID, displ
 		return nil, err
 	}
 
-	if err := s.aclManager.AddWonderNetToPolicy(ctx, hsUserObj.GetName()); err != nil {
-		return nil, err
+	// In tagged mode the constant-size policy (autogroup:self) already covers
+	// every WonderNet, so no per-WonderNet policy mutation is needed. This also
+	// avoids the SetPolicy + peer-map rebuild cost on every signup.
+	if !s.useTaggedACL {
+		if err := s.aclManager.AddWonderNetToPolicy(ctx, hsUserObj.GetName()); err != nil {
+			return nil, err
+		}
 	}
 
 	return newWonderNet, nil
@@ -77,6 +85,10 @@ func (s *WonderNetService) EnsureHeadscaleWonderNet(ctx context.Context, headsca
 	hsUserObj, err := s.wonderNetManager.GetOrCreateWonderNet(ctx, headscaleUser)
 	if err != nil {
 		return err
+	}
+
+	if s.useTaggedACL {
+		return nil
 	}
 
 	return s.aclManager.AddWonderNetToPolicy(ctx, hsUserObj.GetName())
@@ -100,6 +112,17 @@ func (s *WonderNetService) GetPublicURL() string {
 // When a privileged network is configured, a hub-spoke policy is used;
 // otherwise, pure isolation policy is applied.
 func (s *WonderNetService) InitializeACLPolicy(ctx context.Context) error {
+	if s.useTaggedACL {
+		// Tag existing privileged nodes first so there is no transient window
+		// in which a privileged node lacks tag:privileged under the new policy,
+		// then switch to the constant-size policy. Tagging requires no node
+		// action; tags propagate through the next mapper poll.
+		if err := s.aclManager.EnsurePrivilegedTags(ctx, s.privilegedNetworks); err != nil {
+			return fmt.Errorf("ensure privileged tags: %w", err)
+		}
+		return s.aclManager.SetTaggedHubSpokePolicy(ctx, s.privilegedNetworks)
+	}
+
 	if len(s.privilegedNetworks) > 0 {
 		return s.aclManager.SetHubSpokePolicy(ctx, s.privilegedNetworks)
 	}

--- a/internal/app/coordinator/service/wondernet.go
+++ b/internal/app/coordinator/service/wondernet.go
@@ -19,12 +19,13 @@ var (
 
 // WonderNetService manages wonder net provisioning and Headscale integration.
 type WonderNetService struct {
-	wonderNetRepository *repository.WonderNetRepository
-	wonderNetManager    *headscale.WonderNetManager
-	aclManager          *headscale.ACLManager
-	publicURL           string
-	privilegedNetworks  []string
-	useTaggedACL        bool
+	wonderNetRepository  *repository.WonderNetRepository
+	wonderNetManager     *headscale.WonderNetManager
+	aclManager           *headscale.ACLManager
+	publicURL            string
+	privilegedNetworks   []string
+	useTaggedACL         bool
+	strictPrivilegedTags bool
 }
 
 // NewWonderNetService creates a new WonderNetService.
@@ -35,14 +36,16 @@ func NewWonderNetService(
 	publicURL string,
 	privilegedNetworks []string,
 	useTaggedACL bool,
+	strictPrivilegedTags bool,
 ) *WonderNetService {
 	return &WonderNetService{
-		wonderNetRepository: wonderNetRepository,
-		wonderNetManager:    wonderNetManager,
-		aclManager:          aclManager,
-		publicURL:           publicURL,
-		privilegedNetworks:  privilegedNetworks,
-		useTaggedACL:        useTaggedACL,
+		wonderNetRepository:  wonderNetRepository,
+		wonderNetManager:     wonderNetManager,
+		aclManager:           aclManager,
+		publicURL:            publicURL,
+		privilegedNetworks:   privilegedNetworks,
+		useTaggedACL:         useTaggedACL,
+		strictPrivilegedTags: strictPrivilegedTags,
 	}
 }
 
@@ -118,7 +121,13 @@ func (s *WonderNetService) InitializeACLPolicy(ctx context.Context) error {
 		// then switch to the constant-size policy. Tagging requires no node
 		// action; tags propagate through the next mapper poll.
 		if err := s.aclManager.EnsurePrivilegedTags(ctx, s.privilegedNetworks); err != nil {
-			return fmt.Errorf("ensure privileged tags: %w", err)
+			if s.strictPrivilegedTags {
+				return fmt.Errorf("ensure privileged tags: %w", err)
+			}
+			// Non-strict (default): successfully tagged nodes are already
+			// applied and the constant-size policy is still correct, so log and
+			// continue rather than blocking coordinator startup on dirty nodes.
+			slog.Warn("ensure privileged tags (continuing in non-strict mode)", "error", err)
 		}
 		return s.aclManager.SetTaggedHubSpokePolicy(ctx, s.privilegedNetworks)
 	}

--- a/pkg/headscale/acl.go
+++ b/pkg/headscale/acl.go
@@ -4,10 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"slices"
 	"sync"
 
 	v1 "github.com/juanfont/headscale/gen/go/headscale/v1"
 )
+
+// PrivilegedTag is the Headscale tag carried by nodes that belong to a
+// privileged network. Nodes assigned this tag (via forced_tags) reach every
+// node in the mesh.
+const PrivilegedTag = "tag:privileged"
 
 // ACLPolicy represents a Headscale ACL policy
 type ACLPolicy struct {
@@ -66,6 +73,43 @@ func GenerateHubSpokePolicy(privilegedUsers []string, normalUsers []string) *ACL
 	}
 
 	return &ACLPolicy{ACLs: rules}
+}
+
+// GenerateTaggedHubSpokePolicy returns an ACL policy whose size is independent
+// of the WonderNet count: at most two rules regardless of how many users exist.
+//
+//	tag:privileged    -> *:*               (privileged nodes reach everything)
+//	autogroup:member  -> autogroup:self:*  (every normal node reaches only its own nodes)
+//
+// The self-isolation rule relies on Headscale's autogroup:self semantics:
+// although the source is autogroup:member (all untagged nodes), the policy
+// engine narrows both source and destination to the same user per node, so a
+// member only ever sees its own untagged devices. autogroup:self is only valid
+// in destinations, so the source must be autogroup:member.
+//
+// privilegedTagOwners is the list of Headscale usernames allowed to own
+// tag:privileged. Actual per-node tag assignment happens out of band via
+// SetTags (forced_tags) so existing nodes need not reconnect or re-register.
+func GenerateTaggedHubSpokePolicy(privilegedTagOwners []string) *ACLPolicy {
+	policy := &ACLPolicy{
+		ACLs: []ACLRule{
+			{Action: "accept", Sources: []string{"autogroup:member"}, Destinations: []string{"autogroup:self:*"}},
+		},
+	}
+
+	if len(privilegedTagOwners) > 0 {
+		owners := make([]string, len(privilegedTagOwners))
+		for i, u := range privilegedTagOwners {
+			owners[i] = u + "@"
+		}
+		policy.TagOwners = map[string][]string{PrivilegedTag: owners}
+		// Prepend the privileged rule so it is evaluated first.
+		policy.ACLs = append([]ACLRule{
+			{Action: "accept", Sources: []string{PrivilegedTag}, Destinations: []string{"*:*"}},
+		}, policy.ACLs...)
+	}
+
+	return policy
 }
 
 // ACLManager manages ACL policies in Headscale
@@ -137,6 +181,73 @@ func (am *ACLManager) SetHubSpokePolicy(ctx context.Context, privilegedUsers []s
 
 	_, err = am.client.SetPolicy(ctx, &v1.SetPolicyRequest{Policy: string(policyJSON)})
 	return err
+}
+
+// SetTaggedHubSpokePolicy writes the constant-size tag-based policy. It does
+// not touch any node's tags; use EnsurePrivilegedTags for that.
+func (am *ACLManager) SetTaggedHubSpokePolicy(ctx context.Context, privilegedUsers []string) error {
+	am.mu.Lock()
+	defer am.mu.Unlock()
+
+	policy := GenerateTaggedHubSpokePolicy(privilegedUsers)
+	policyJSON, err := json.Marshal(policy)
+	if err != nil {
+		return fmt.Errorf("marshal policy: %w", err)
+	}
+
+	_, err = am.client.SetPolicy(ctx, &v1.SetPolicyRequest{Policy: string(policyJSON)})
+	return err
+}
+
+// EnsurePrivilegedTags assigns PrivilegedTag to every node owned by a user in
+// privilegedUsers via Headscale's forced_tags mechanism. It is idempotent and
+// preserves any existing tags on each node. Tag changes propagate through the
+// next mapper poll, so nodes do not need to reconnect or re-register.
+func (am *ACLManager) EnsurePrivilegedTags(ctx context.Context, privilegedUsers []string) error {
+	am.mu.Lock()
+	defer am.mu.Unlock()
+
+	if len(privilegedUsers) == 0 {
+		return nil
+	}
+
+	privileged := make(map[string]struct{}, len(privilegedUsers))
+	for _, u := range privilegedUsers {
+		privileged[u] = struct{}{}
+	}
+
+	resp, err := am.client.ListNodes(ctx, &v1.ListNodesRequest{})
+	if err != nil {
+		return fmt.Errorf("list nodes: %w", err)
+	}
+
+	var tagged, skipped, failed int
+	for _, node := range resp.GetNodes() {
+		if _, ok := privileged[node.GetUser().GetName()]; !ok {
+			continue
+		}
+		if slices.Contains(node.GetForcedTags(), PrivilegedTag) {
+			skipped++
+			continue
+		}
+
+		newTags := append(slices.Clone(node.GetForcedTags()), PrivilegedTag)
+		if _, err := am.client.SetTags(ctx, &v1.SetTagsRequest{
+			NodeId: node.GetId(),
+			Tags:   newTags,
+		}); err != nil {
+			slog.Warn("set privileged tag", "node_id", node.GetId(), "user", node.GetUser().GetName(), "error", err)
+			failed++
+			continue
+		}
+		tagged++
+	}
+
+	slog.Info("privileged tag sync", "tagged", tagged, "skipped", skipped, "failed", failed)
+	if failed > 0 {
+		return fmt.Errorf("privileged tag sync: %d node(s) failed", failed)
+	}
+	return nil
 }
 
 // AddWonderNetToPolicy adds a wonder net to the isolation policy

--- a/pkg/headscale/acl.go
+++ b/pkg/headscale/acl.go
@@ -250,7 +250,12 @@ func (am *ACLManager) EnsurePrivilegedTags(ctx context.Context, privilegedUsers 
 	return nil
 }
 
-// AddWonderNetToPolicy adds a wonder net to the isolation policy
+// AddWonderNetToPolicy adds a wonder net to the isolation policy.
+//
+// Only the legacy per-user policy path calls this. When UseTaggedACL is
+// enabled the constant-size policy covers every WonderNet via autogroup:self,
+// so this is intentionally not invoked. Kept for the non-tagged (default) path
+// and for rollback; do not remove until the legacy path is retired.
 func (am *ACLManager) AddWonderNetToPolicy(ctx context.Context, username string) error {
 	am.mu.Lock()
 	defer am.mu.Unlock()

--- a/pkg/headscale/acl_test.go
+++ b/pkg/headscale/acl_test.go
@@ -1,6 +1,7 @@
 package headscale
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -49,6 +50,51 @@ func TestGenerateHubSpokePolicy_NoNormalUsers(t *testing.T) {
 	}
 
 	assertRule(t, policy.ACLs[0], "accept", []string{"zeabur@"}, []string{"*:*"})
+}
+
+func TestGenerateTaggedHubSpokePolicy_ConstantSize(t *testing.T) {
+	for _, n := range []int{0, 1, 10, 2105} {
+		owners := make([]string, n)
+		for i := range owners {
+			owners[i] = fmt.Sprintf("u%d", i)
+		}
+
+		policy := GenerateTaggedHubSpokePolicy(owners)
+
+		want := 2
+		if n == 0 {
+			want = 1
+		}
+		if len(policy.ACLs) != want {
+			t.Errorf("n=%d: expected %d rules, got %d", n, want, len(policy.ACLs))
+		}
+	}
+}
+
+func TestGenerateTaggedHubSpokePolicy_RuleShape(t *testing.T) {
+	policy := GenerateTaggedHubSpokePolicy([]string{"zeabur"})
+
+	owners := policy.TagOwners[PrivilegedTag]
+	if len(owners) != 1 || owners[0] != "zeabur@" {
+		t.Errorf("tag owners: expected [zeabur@], got %v", owners)
+	}
+
+	assertRule(t, policy.ACLs[0], "accept", []string{PrivilegedTag}, []string{"*:*"})
+	// autogroup:self is only valid in destinations; the source must be
+	// autogroup:member, and the engine narrows it to the same user per node.
+	assertRule(t, policy.ACLs[1], "accept", []string{"autogroup:member"}, []string{"autogroup:self:*"})
+}
+
+func TestGenerateTaggedHubSpokePolicy_NoPrivileged(t *testing.T) {
+	policy := GenerateTaggedHubSpokePolicy(nil)
+
+	if len(policy.ACLs) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(policy.ACLs))
+	}
+	if policy.TagOwners != nil {
+		t.Errorf("expected no tag owners, got %v", policy.TagOwners)
+	}
+	assertRule(t, policy.ACLs[0], "accept", []string{"autogroup:member"}, []string{"autogroup:self:*"})
 }
 
 func assertRule(t *testing.T, rule ACLRule, action string, src, dst []string) {


### PR DESCRIPTION
The per-user ACL policy (SetHubSpokePolicy / AddWonderNetToPolicy) grows O(users): one rule per WonderNet plus one per privileged user. On large clusters this produces thousands of rules (~2105 observed), and Headscale v2's unindexed policy engine re-evaluates every rule against every peer on each RegisterReq / peer-map rebuild. The cost can exceed containerboot's `tailscale up` timeout and crashloop nodes.

Add an opt-in constant-size policy (USE_TAGGED_ACL / --use-tagged-acl, default off) that is always at most two rules regardless of WonderNet count:

  tag:privileged    -> *:*               (privileged nodes reach all)
  autogroup:member  -> autogroup:self:*  (members reach only own nodes)

autogroup:self is only valid in destinations, so the self-isolation source is autogroup:member; Headscale narrows it to the same user per node, preserving the existing per-WonderNet isolation semantics.

Privileged nodes are migrated to tag:privileged via Headscale's forced_tags (SetTags gRPC) on coordinator startup, before the new policy is written. Tagging requires no node action — tags propagate through the next mapper poll, so existing nodes do not reconnect or re-register. In tagged mode new WonderNets no longer mutate the policy, avoiding the SetPolicy + peer-map rebuild cost on every signup.

The legacy path is kept behind the flag for rollback.